### PR TITLE
Never throw a null exception

### DIFF
--- a/src/Microsoft.Dism.Tests/DismExceptionTest.cs
+++ b/src/Microsoft.Dism.Tests/DismExceptionTest.cs
@@ -68,6 +68,24 @@ namespace Microsoft.Dism.Tests
         }
 
         [Fact]
+        public void ReloadSessionRequiredButNoSession()
+        {
+            DismException exception = Should.Throw<DismException>(() => DismUtilities.ThrowIfFail(1, session: null));
+
+            exception.HResult.ShouldBe(1);
+            exception.Message.ShouldBe($"The {nameof(ReloadSessionRequiredButNoSession)} function returned DISMAPI_S_RELOAD_IMAGE_SESSION_REQUIRED but was not passed a session to reload.");
+        }
+
+        [Fact]
+        public void UnknownErrorThrowsDismExceptionWithHResult()
+        {
+            DismException exception = Should.Throw<DismException>(() => DismUtilities.ThrowIfFail(3));
+
+            exception.HResult.ShouldBe(3);
+            exception.Message.ShouldBe($"The {nameof(UnknownErrorThrowsDismExceptionWithHResult)} function returned the error code 0x00000003");
+        }
+
+        [Fact]
         public void Win32ExceptionTest()
         {
             const int errorCode = unchecked((int)0x80020012);

--- a/src/Microsoft.Dism/CallerMemberNameAttribute.cs
+++ b/src/Microsoft.Dism/CallerMemberNameAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c). All rights reserved.
+//
+// Licensed under the MIT license.
+
+#if NET40
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Allows you to obtain the method or property name of the caller to the method.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public class CallerMemberNameAttribute : Attribute
+    {
+    }
+}
+#endif


### PR DESCRIPTION
This fixes a code path where the hresult cannot be translated into an exception which ends up throwing null.

I also added a new exception if the called function indicates that a reload is required but the caller did not pass in a session.

Related to #95