### PR TITLE
Fix DismCapabilityInfo.DownloadSize and DismCapabilityInfo.InstallSize

### DIFF
--- a/src/Microsoft.Dism.Tests/DismCapabilityInfoTest.cs
+++ b/src/Microsoft.Dism.Tests/DismCapabilityInfoTest.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using Shouldly;
+using Xunit;
 
 namespace Microsoft.Dism.Tests
 {
@@ -27,14 +28,29 @@ namespace Microsoft.Dism.Tests
 
         protected override object Struct => _capabilityInfo;
 
+        [Fact]
+        public void DownloadAndInstallSizeDoNotOverflow()
+        {
+            DismApi.DismCapabilityInfo_ dismCapabilityInfo = new DismApi.DismCapabilityInfo_
+            {
+                DownloadSize = (uint)int.MaxValue + 1,
+                InstallSize = (uint)int.MaxValue + 10,
+            };
+
+            DismCapabilityInfo capabilityInfo = new DismCapabilityInfo(dismCapabilityInfo);
+
+            capabilityInfo.DownloadSize.ShouldBe((uint)int.MaxValue + 1);
+            capabilityInfo.InstallSize.ShouldBe((uint)int.MaxValue + 10);
+        }
+
         protected override void VerifyProperties(DismCapabilityInfo item)
         {
             item.Name.ShouldBe(_capabilityInfo.Name);
             item.DisplayName.ShouldBe(_capabilityInfo.DisplayName);
             item.Description.ShouldBe(_capabilityInfo.Description);
             item.State.ShouldBe(_capabilityInfo.State);
-            item.DownloadSize.ShouldBe((int)_capabilityInfo.DownloadSize);
-            item.InstallSize.ShouldBe((int)_capabilityInfo.InstallSize);
+            item.DownloadSize.ShouldBe(_capabilityInfo.DownloadSize);
+            item.InstallSize.ShouldBe(_capabilityInfo.InstallSize);
         }
     }
 }

--- a/src/Microsoft.Dism/DismCapabilityInfo.cs
+++ b/src/Microsoft.Dism/DismCapabilityInfo.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Dism
             /// <summary>
             /// The download size of the capability in bytes.
             /// </summary>
-            public UInt32 DownloadSize;
+            public uint DownloadSize;
 
             /// <summary>
             /// The install size of the capability in bytes.
             /// </summary>
-            public UInt32 InstallSize;
+            public uint InstallSize;
         }
     }
 
@@ -70,8 +70,17 @@ namespace Microsoft.Dism
         /// </summary>
         /// <param name="capabilityPtr">An <see cref="IntPtr" /> of a <see cref="DismApi.DismCapabilityInfo_" /> structure.</param>
         internal DismCapabilityInfo(IntPtr capabilityPtr)
+            : this(capabilityPtr.ToStructure<DismApi.DismCapabilityInfo_>())
         {
-            _capabilityInfo = capabilityPtr.ToStructure<DismApi.DismCapabilityInfo_>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DismCapabilityInfo" /> class.
+        /// </summary>
+        /// <param name="capabilityInfo">A <see cref="DismApi.DismCapabilityInfo_" /> structure containing the capability information.</param>
+        internal DismCapabilityInfo(DismApi.DismCapabilityInfo_ capabilityInfo)
+        {
+            _capabilityInfo = capabilityInfo;
         }
 
         /// <summary>
@@ -97,12 +106,12 @@ namespace Microsoft.Dism
         /// <summary>
         /// Gets the download size of the capability in bytes.
         /// </summary>
-        public int DownloadSize => (int)_capabilityInfo.DownloadSize;
+        public uint DownloadSize => _capabilityInfo.DownloadSize;
 
         /// <summary>
         /// Gets the install size of the capability in bytes.
         /// </summary>
-        public int InstallSize => (int)_capabilityInfo.InstallSize;
+        public uint InstallSize => _capabilityInfo.InstallSize;
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
@@ -140,8 +149,8 @@ namespace Microsoft.Dism
                 ^ State.GetHashCode()
                 ^ (string.IsNullOrEmpty(DisplayName) ? 0 : DisplayName.GetHashCode())
                 ^ (string.IsNullOrEmpty(Description) ? 0 : Description.GetHashCode())
-                ^ DownloadSize
-                ^ InstallSize;
+                ^ (int)DownloadSize
+                ^ (int)InstallSize;
         }
     }
 }

--- a/src/Microsoft.Dism/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Dism/PublicAPI.Shipped.txt
@@ -45,9 +45,7 @@ Microsoft.Dism.DismCapabilityCollection
 Microsoft.Dism.DismCapabilityInfo
 Microsoft.Dism.DismCapabilityInfo.Description.get -> string!
 Microsoft.Dism.DismCapabilityInfo.DisplayName.get -> string!
-Microsoft.Dism.DismCapabilityInfo.DownloadSize.get -> int
 Microsoft.Dism.DismCapabilityInfo.Equals(Microsoft.Dism.DismCapabilityInfo? other) -> bool
-Microsoft.Dism.DismCapabilityInfo.InstallSize.get -> int
 Microsoft.Dism.DismCapabilityInfo.Name.get -> string!
 Microsoft.Dism.DismCapabilityInfo.State.get -> Microsoft.Dism.DismPackageFeatureState
 Microsoft.Dism.DismCustomProperty

--- a/src/Microsoft.Dism/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Dism/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.Dism.DismCapabilityInfo.DownloadSize.get -> uint
+Microsoft.Dism.DismCapabilityInfo.InstallSize.get -> uint

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.5",
+  "version": "3.0",
   "assemblyVersion": "1.0",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [


### PR DESCRIPTION
These properties should be a `uint` instead to align with the native structure

Fixes #209