### PR TITLE
Fix test to account for staged capabilities

### DIFF
--- a/src/Microsoft.Dism.Tests/GetCapabilitiesTest.cs
+++ b/src/Microsoft.Dism.Tests/GetCapabilitiesTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Dism.Tests
                 {
                     capability.Name.ShouldNotBeNullOrWhiteSpace();
 
-                    capability.State.ShouldBeOneOf(DismPackageFeatureState.Installed, DismPackageFeatureState.NotPresent);
+                    capability.State.ShouldBeOneOf(DismPackageFeatureState.Installed, DismPackageFeatureState.Staged, DismPackageFeatureState.NotPresent);
                 }
             }
         }


### PR DESCRIPTION
The test fixed in this commit was failing on my machine because the capability _Print Management_ is _staged_.